### PR TITLE
Changed AsJson to ToJson and made indented json the default for printAsJson

### DIFF
--- a/Documentation/Extensions.md
+++ b/Documentation/Extensions.md
@@ -128,10 +128,10 @@ var myModel = new MyModel();
 
 // Returns a JSON-string representation of the object.
 // Enums are converted to string representations
-string jsonString = myModel.AsJson();
+string jsonString = myModel.ToJson();
 
 // Same as above except that the JSON is indented and not compact
-string indentedJsonString = myModel.AsIndentedJson();
+string indentedJsonString = myModel.ToIndentedJson();
 
 // For debugging purposes. Prints the entire object as JSON via `Console.Writeline` 
 myModel.PrintAsJson();

--- a/Source/SCM.SwissArmyKnife/Extensions/ObjectExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/ObjectExtensions.cs
@@ -16,6 +16,7 @@ namespace SCM.SwissArmyKnife.Extensions
         /// Converts Enums to their string values.
         /// </summary>
         [Pure]
+        [Obsolete("Use ToJson instead")]
         public static string AsJson(this object objectToSerialize)
         {
             return JsonConvert.SerializeObject(
@@ -27,6 +28,7 @@ namespace SCM.SwissArmyKnife.Extensions
         /// Converts Enums to their string values.
         /// </summary>
         [Pure]
+        [Obsolete("Use ToIndentedJson instead")]
         public static string AsIndentedJson(this object objectToSerialize)
         {
             return JsonConvert.SerializeObject(
@@ -34,12 +36,34 @@ namespace SCM.SwissArmyKnife.Extensions
         }
 
         /// <summary>
-        /// Shortcut for Console.Writeline(object.AsJson())
+        /// Creates an object and turns it into an indented JSON string
+        /// Converts Enums to their string values.
+        /// </summary>
+        [Pure]
+        public static string ToIndentedJson(this object objectToSerialize)
+        {
+            return JsonConvert.SerializeObject(
+                objectToSerialize, Formatting.Indented, new StringEnumConverter());
+        }
+
+        /// <summary>
+        /// Creates an object and turns it into a compact JSON string
+        /// Converts Enums to their string values.
+        /// </summary>
+        [Pure]
+        public static string ToJson(this object objectToSerialize)
+        {
+            return JsonConvert.SerializeObject(
+                objectToSerialize, new StringEnumConverter());
+        }
+
+        /// <summary>
+        /// Shortcut for Console.Writeline(object.ToIndentedJson())
         /// Use only for debugging purposes.
         /// </summary>
         public static void PrintAsJson(this object objectToPrint)
         {
-            Console.WriteLine(objectToPrint.AsJson());
+            Console.WriteLine(objectToPrint.ToIndentedJson());
         }
     }
 }

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/ObjectExtensionTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/ObjectExtensionTests.cs
@@ -7,26 +7,26 @@ namespace SCM.SwissArmyKnife.Test.Extensions
     public class ObjectExtensionTests
     {
         [Fact]
-        public void AsJson_ShouldConvertObject_ToString_And_SerializeEnums_AsString()
+        public void ToJson_ShouldConvertObject_ToString_And_SerializeEnums_AsString()
         {
             // Arrange
             var testModel = new TestModel() { MyValue = 3, MyEnum = TestEnum.SecondOption };
 
             // Act
-            var jsonString = testModel.AsJson();
+            var jsonString = testModel.ToJson();
 
             // Assert.
             jsonString.Should().Be(@"{""MyValue"":3,""MyEnum"":""SecondOption""}");
         }
 
         [Fact]
-        public void AsJsonIndented_ShouldConvertObject_ToString_And_SerializeEnums_AsString()
+        public void ToJsonIndented_ShouldConvertObject_ToString_And_SerializeEnums_AsString()
         {
             // Arrange
             var testModel = new TestModel() { MyValue = 3, MyEnum = TestEnum.SecondOption };
 
             // Act
-            var jsonString = testModel.AsIndentedJson();
+            var jsonString = testModel.ToIndentedJson();
 
             // Assert.
             jsonString.Should().Be(@"{


### PR DESCRIPTION
Closes #15 
Closes #14 

Convert `AsJson` to `ToJson` to keep C# syntax from lists. Leaves old methods in with an `obsolete` attribute so we don't have to publish a major release.