### PR TITLE
Add IsSet() string extension

### DIFF
--- a/Documentation/Extensions.md
+++ b/Documentation/Extensions.md
@@ -192,5 +192,8 @@ string.Truncate(maxLength: 10);
 
 // Returns "hel..."
 string.Truncate(maxLength: 3);
+
+// Returns true
+string.IsSet();
 ```
 \ref SCM.SwissArmyKnife.Extensions.StringExtensions "View More Documentation"

--- a/Source/SCM.SwissArmyKnife/Extensions/StringExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/StringExtensions.cs
@@ -45,5 +45,15 @@ namespace SCM.SwissArmyKnife.Extensions
 
             return @this.Substring(0, maxLength) + "...";
         }
+
+        /// <summary>
+        /// Checks if the string has been set, i.e it is not null or an empty string.
+        /// </summary>
+        /// <returns>Returns true if <paramref name="this"/> is not null or an empty string.</returns>
+        [Pure]
+        public static bool IsSet(this string @this)
+        {
+            return string.IsNullOrEmpty(@this) == false;
+        }
     }
 }

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/StringExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/StringExtensionsTests.cs
@@ -47,5 +47,24 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         {
             "123".Truncate(3).Should().Be("123");
         }
+
+        [Fact]
+        public void IsSet_ReturnsTrueIf_StringIsNotNullOrEmpty()
+        {
+            "123".IsSet().Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsSet_ReturnsFalseIf_StringIsEmtpy()
+        {
+            string.Empty.IsSet().Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsSet_ReturnsFalseIf_StringIsNull()
+        {
+            ((string)null!).IsSet().Should().BeFalse();
+        }
+
     }
 }


### PR DESCRIPTION
Adds a convinence string extensions called `IsSet()` which is essentially just a shorter `string.IsNullOrEmpty(...)` and also returns the inverse (returns false when it is null or empty)