### PR TITLE
Added a dictionary extension method ConvertValueToNewType 

### DIFF
--- a/Documentation/Extensions.md
+++ b/Documentation/Extensions.md
@@ -14,6 +14,18 @@ myDictionary.GetOrThrow("nonExistingKey", () => new ArgumentException("tried to 
 
 // Will return "myFallbackValue"
 myDictionary.GetOr("nonExistingKey", () => "myFallbackValue");
+
+var myDictionary = new Dictionary<string, string> {
+    {"myKey", "2"}
+}
+ // Will return a new dictionary where values type is integer
+ var convertedValueDictionary = myDictionary.ConvertValuesToNewType<string, string, int>("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+     
+// Will throw InvalidOperationException
+var myDictionary = new Dictionary<string, string> {
+    {"myKey", "bar"}
+}
+var throwsOnConvertDictionary = myDictionary.ConvertValuesToNewType<string, string, int>("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 ```
 
 \ref SCM.SwissArmyKnife.Extensions.DictionaryExtensions "View More Documentation"

--- a/Documentation/Extensions.md
+++ b/Documentation/Extensions.md
@@ -21,10 +21,7 @@ var myIntDictionary = new Dictionary<string, string> {
  // Will return a new dictionary where values type is integer
  var convertedValueDictionary = myIntDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
      
-// Will throw exception
-var myDictionary = new Dictionary<string, string> {
-    {"myKey", "bar"}
-}
+// Using <string,string> dictionary from earlier with unparsable string. Will throw exception
 var throwsOnConvertDictionary = myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 ```
 

--- a/Documentation/Extensions.md
+++ b/Documentation/Extensions.md
@@ -15,17 +15,17 @@ myDictionary.GetOrThrow("nonExistingKey", () => new ArgumentException("tried to 
 // Will return "myFallbackValue"
 myDictionary.GetOr("nonExistingKey", () => "myFallbackValue");
 
-var myDictionary = new Dictionary<string, string> {
+var myIntDictionary = new Dictionary<string, string> {
     {"myKey", "2"}
 }
  // Will return a new dictionary where values type is integer
- var convertedValueDictionary = myDictionary.ConvertValuesToNewType<string, string, int>("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+ var convertedValueDictionary = myIntDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
      
-// Will throw InvalidOperationException
+// Will throw exception
 var myDictionary = new Dictionary<string, string> {
     {"myKey", "bar"}
 }
-var throwsOnConvertDictionary = myDictionary.ConvertValuesToNewType<string, string, int>("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+var throwsOnConvertDictionary = myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 ```
 
 \ref SCM.SwissArmyKnife.Extensions.DictionaryExtensions "View More Documentation"

--- a/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
@@ -67,16 +67,16 @@ namespace SCM.SwissArmyKnife.Extensions
         /// var myDictionary = new Dictionary&lt;string, string&gt; {
         ///     {"myKey", "2"}
         /// }
-        /// myDictionary.ConvertValuesToNewType&lt;string, string, int>("myKey", oldValue => int.Parse(oldValue));
+        /// myDictionary.ConvertValuesToNewType&lt;string, string, int&gt;("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         ///
         /// // Will throw InvalidOperationException
         /// var myDictionary = new Dictionary&lt;string, string&gt; {
         ///     {"myKey", "bar"}
         /// }
-        /// myDictionary.ConvertValuesToNewType&lt;string, string, int>("myKey", oldValue => int.Parse(oldValue));
+        /// myDictionary.ConvertValuesToNewType&lt;string, string, int&gt;("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         /// </code>
         /// </example>
-        /// <returns>Dictioanary&lt;K, N></returns>
+        /// <returns>Dictioanary&lt;K, N&gt;</returns>
         public static Dictionary<K, N> ConvertValuesToNewType<K, O, N>(
             this IReadOnlyDictionary<K, O> dictionary,
             Func<O, N> convertionFunction)

--- a/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 
-
 namespace SCM.SwissArmyKnife.Extensions
 {
     /// <summary>
@@ -53,51 +52,38 @@ namespace SCM.SwissArmyKnife.Extensions
         }
 
         /// <summary>
-        /// Converts the values in the given dictionary to the new type using the provided convert function. Throws when the value cannot be converted.
+        /// Returns a new dictionary after appling the provided function to each value from the given dictionary.
         /// </summary>
         /// <typeparam name="K">Key Type.</typeparam>
         /// <typeparam name="O">Original Type.</typeparam>
         /// <typeparam name="N">New Type.</typeparam>
         /// <param name="dictionary">Source Dictionary.</param>
-        /// <param name="convertionFunction">Convert function.</param>
-        /// <exception cref="InvalidOperationException"> Throws when the provided convert function is not able to convert the value.</exception>
+        /// <param name="selector">Selector function.</param>
         /// <example>
         /// <code>
         /// // Will return a new dictionary where value type is integer
         /// var myDictionary = new Dictionary&lt;string, string&gt; {
         ///     {"myKey", "2"}
         /// }
-        /// myDictionary.ConvertValuesToNewType&lt;string, string, int&gt;("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+        /// myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         ///
-        /// // Will throw InvalidOperationException
+        /// // Will throw exception
         /// var myDictionary = new Dictionary&lt;string, string&gt; {
         ///     {"myKey", "bar"}
         /// }
-        /// myDictionary.ConvertValuesToNewType&lt;string, string, int&gt;("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+        /// myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         /// </code>
         /// </example>
         /// <returns>Dictioanary&lt;K, N&gt;</returns>
-        public static Dictionary<K, N> ConvertValuesToNewType<K, O, N>(
+        public static Dictionary<K, N> SelectValues<K, O, N>(
             this IReadOnlyDictionary<K, O> dictionary,
-            Func<O, N> convertionFunction)
+            Func<O, N> selector)
         {
             var newDictionary = new Dictionary<K, N>();
 
-            if (dictionary.Count == 0)
-            {
-                return newDictionary;
-            }
-
             foreach (var keyValuePair in dictionary)
             {
-                try
-                {
-                    newDictionary.Add(keyValuePair.Key, convertionFunction(keyValuePair.Value));
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidOperationException("Tried converting the value but encountered an error", ex);
-                }
+                newDictionary.Add(keyValuePair.Key, selector(keyValuePair.Value));
             }
 
             return newDictionary;

--- a/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
@@ -54,9 +54,9 @@ namespace SCM.SwissArmyKnife.Extensions
         /// <summary>
         /// Returns a new dictionary after appling the provided function to each value from the given dictionary.
         /// </summary>
-        /// <typeparam name="K">Key Type.</typeparam>
-        /// <typeparam name="O">Original Type.</typeparam>
-        /// <typeparam name="N">New Type.</typeparam>
+        /// <typeparam name="TKey">Key Type.</typeparam>
+        /// <typeparam name="TOldValue">Original Type.</typeparam>
+        /// <typeparam name="TNewValue">New Type.</typeparam>
         /// <param name="dictionary">Source Dictionary.</param>
         /// <param name="selector">Selector function.</param>
         /// <example>
@@ -74,12 +74,12 @@ namespace SCM.SwissArmyKnife.Extensions
         /// myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         /// </code>
         /// </example>
-        /// <returns>Dictioanary&lt;K, N&gt;</returns>
-        public static Dictionary<K, N> SelectValues<K, O, N>(
-            this IReadOnlyDictionary<K, O> dictionary,
-            Func<O, N> selector)
+        /// <returns>Dictioanary&lt;K, N&gt;.</returns>
+        public static Dictionary<TKey, TNewValue> SelectValues<TKey, TOldValue, TNewValue>(
+            this IReadOnlyDictionary<TKey, TOldValue> dictionary,
+            Func<TOldValue, TNewValue> selector)
         {
-            var newDictionary = new Dictionary<K, N>();
+            var newDictionary = new Dictionary<TKey, TNewValue>();
 
             foreach (var keyValuePair in dictionary)
             {

--- a/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
@@ -51,5 +51,56 @@ namespace SCM.SwissArmyKnife.Extensions
         {
             return dictionary.TryGetValue(key, out var value) ? value : valueProducer();
         }
+
+        /// <summary>
+        /// Converts the values in the given dictionary to the new type using the provided convert function. Throws when the value cannot be converted.
+        /// </summary>
+        /// <typeparam name="K">Key Type.</typeparam>
+        /// <typeparam name="O">Original Type.</typeparam>
+        /// <typeparam name="N">New Type.</typeparam>
+        /// <param name="dictionary">Source Dictionary.</param>
+        /// <param name="convertionFunction">Convert function.</param>
+        /// <exception cref="InvalidOperationException"> Throws when the provided convert function is not able to convert the value.</exception>
+        /// <example>
+        /// <code>
+        /// // Will return a new dictionary where value type is integer
+        /// var myDictionary = new Dictionary&lt;string, string&gt; {
+        ///     {"myKey", "2"}
+        /// }
+        /// myDictionary.ConvertValuesToNewType&lt;string, string, int>("myKey", oldValue => int.Parse(oldValue));
+        ///
+        /// // Will throw InvalidOperationException
+        /// var myDictionary = new Dictionary&lt;string, string&gt; {
+        ///     {"myKey", "bar"}
+        /// }
+        /// myDictionary.ConvertValuesToNewType&lt;string, string, int>("myKey", oldValue => int.Parse(oldValue));
+        /// </code>
+        /// </example>
+        /// <returns>Dictioanary&lt;K, N></returns>
+        public static Dictionary<K, N> ConvertValuesToNewType<K, O, N>(
+            this IReadOnlyDictionary<K, O> dictionary,
+            Func<O, N> convertionFunction)
+        {
+            var newDictionary = new Dictionary<K, N>();
+
+            if (dictionary.Count == 0)
+            {
+                return newDictionary;
+            }
+
+            foreach (var keyValuePair in dictionary)
+            {
+                try
+                {
+                    newDictionary.Add(keyValuePair.Key, convertionFunction(keyValuePair.Value));
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Tried converting the value but encountered an error", ex);
+                }
+            }
+
+            return newDictionary;
+        }
     }
 }

--- a/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
@@ -74,7 +74,7 @@ namespace SCM.SwissArmyKnife.Extensions
         /// myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         /// </code>
         /// </example>
-        /// <returns>Dictioanary&lt;K, N&gt;.</returns>
+        /// <returns>Dictioanary&lt;TKey, TNewValue&gt;.</returns>
         public static Dictionary<TKey, TNewValue> SelectValues<TKey, TOldValue, TNewValue>(
             this IReadOnlyDictionary<TKey, TOldValue> dictionary,
             Func<TOldValue, TNewValue> selector)

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using FluentAssertions;
 using SCM.SwissArmyKnife.Extensions;
 using Xunit;
@@ -79,7 +80,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             };
 
             // Act
-            var convertedValueDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue));
+            var convertedValueDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
             convertedValueDictionary.TryGetValue("foo", out var returnValue);
@@ -94,7 +95,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             var dictionary = new Dictionary<string, string>();
 
             // Act
-            var convertedEmptyDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue));
+            var convertedEmptyDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
             var arguments = convertedEmptyDictionary.GetType().GetGenericArguments();
@@ -114,7 +115,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             };
 
             // Act
-            Action convertAction = () => dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue));
+            Action convertAction = () => dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
             convertAction

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
@@ -69,5 +69,58 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             returnedValue.Should().Be("bar");
         }
 
+        [Fact]
+        public void ConvertValuesToNewType_IfValueExists()
+        {
+            // Arrange
+            var dictionary = new Dictionary<string, string>
+            {
+                {"foo", "2"}
+            };
+
+            // Act
+            var convertedValueDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue));
+
+            // Assert
+            convertedValueDictionary.TryGetValue("foo", out var returnValue);
+
+            returnValue.Should().BeOfType(typeof(int));
+        }
+
+        [Fact]
+        public void ConvertValyesToNewType_IfNoValueExist()
+        {
+            // Arrange
+            var dictionary = new Dictionary<string, string>();
+
+            // Act
+            var convertedEmptyDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue));
+
+            // Assert
+            var arguments = convertedEmptyDictionary.GetType().GetGenericArguments();
+
+            convertedEmptyDictionary.Should().BeEmpty();
+            arguments[0].Should().Be(typeof(string));
+            arguments[1].Should().Be(typeof(int));
+        }
+
+        [Fact]
+        public void ConvertValuesToNewType_ThrowsOnInvalidConvert()
+        {
+            // Arrange
+            var dictionary = new Dictionary<string, string>
+            {
+                {"foo", "bar"}
+            };
+
+            // Act
+            Action convertAction = () => dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue));
+
+            // Assert
+            convertAction
+                .Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("Tried converting the value but encountered an error");
+        }
     }
 }

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
@@ -71,7 +71,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         }
 
         [Fact]
-        public void ConvertValuesToNewType_IfValueExists()
+        public void SelectValues_IfValueExists()
         {
             // Arrange
             var dictionary = new Dictionary<string, string>
@@ -80,7 +80,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             };
 
             // Act
-            var convertedValueDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+            var convertedValueDictionary = dictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
             convertedValueDictionary.TryGetValue("foo", out var returnValue);
@@ -89,24 +89,20 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         }
 
         [Fact]
-        public void ConvertValyesToNewType_IfNoValueExist()
+        public void SelectValues_IfNoValueExist()
         {
             // Arrange
             var dictionary = new Dictionary<string, string>();
 
             // Act
-            var convertedEmptyDictionary = dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+            Dictionary<string, int> convertedEmptyDictionary = dictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
-            var arguments = convertedEmptyDictionary.GetType().GetGenericArguments();
-
             convertedEmptyDictionary.Should().BeEmpty();
-            arguments[0].Should().Be(typeof(string));
-            arguments[1].Should().Be(typeof(int));
         }
 
         [Fact]
-        public void ConvertValuesToNewType_ThrowsOnInvalidConvert()
+        public void SelectValues_ThrowsOnInvalidConvert()
         {
             // Arrange
             var dictionary = new Dictionary<string, string>
@@ -115,13 +111,12 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             };
 
             // Act
-            Action convertAction = () => dictionary.ConvertValuesToNewType<string, string, int>(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+            Action convertAction = () => dictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
             convertAction
                 .Should()
-                .Throw<InvalidOperationException>()
-                .WithMessage("Tried converting the value but encountered an error");
+                .Throw<Exception>();
         }
     }
 }

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/DictionaryExtensionsTests.cs
@@ -83,9 +83,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             var convertedValueDictionary = dictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 
             // Assert
-            convertedValueDictionary.TryGetValue("foo", out var returnValue);
-
-            returnValue.Should().BeOfType(typeof(int));
+            convertedValueDictionary.Should().ContainKey("foo").WhichValue.Should().Be(2);
         }
 
         [Fact]


### PR DESCRIPTION
Description: 
Added a dictionary extension method ConvertValueToNewType converts the values of a given dictionary to a given type using a provided convert function. 

Test:
Tests can found in the appropriate place

Tested with `dotnet cake --target=Test`
<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/Username/Project/blob/main/.github/CONTRIBUTING.md
-->
