### PR TITLE
fixed documentation and comments for select value and added pure annotation

### DIFF
--- a/Documentation/Extensions.md
+++ b/Documentation/Extensions.md
@@ -19,10 +19,10 @@ var myIntDictionary = new Dictionary<string, string> {
     {"myKey", "2"}
 }
  // Will return a new dictionary where values type is integer
- var convertedValueDictionary = myIntDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+ var convertedValueDictionary = myIntDictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
      
-// Using <string,string> dictionary from earlier with unparsable string. Will throw exception
-var throwsOnConvertDictionary = myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+// Using <string, string> dictionary from earlier with unparsable string. Will throw exception
+var throwsOnConvertDictionary = myDictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
 ```
 
 \ref SCM.SwissArmyKnife.Extensions.DictionaryExtensions "View More Documentation"

--- a/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/DictionaryExtensions.cs
@@ -65,16 +65,17 @@ namespace SCM.SwissArmyKnife.Extensions
         /// var myDictionary = new Dictionary&lt;string, string&gt; {
         ///     {"myKey", "2"}
         /// }
-        /// myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+        /// myDictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         ///
         /// // Will throw exception
         /// var myDictionary = new Dictionary&lt;string, string&gt; {
         ///     {"myKey", "bar"}
         /// }
-        /// myDictionary.SelectValues("myKey", oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
+        /// myDictionary.SelectValues(oldValue => int.Parse(oldValue, CultureInfo.InvariantCulture));
         /// </code>
         /// </example>
         /// <returns>Dictioanary&lt;TKey, TNewValue&gt;.</returns>
+        [Pure]
         public static Dictionary<TKey, TNewValue> SelectValues<TKey, TOldValue, TNewValue>(
             this IReadOnlyDictionary<TKey, TOldValue> dictionary,
             Func<TOldValue, TNewValue> selector)


### PR DESCRIPTION
Description: 
Removed the key from when calling `.SelectValues()` in the documentation and method comments. Added pure annotation on the method. 

Testing: 
not the case. 

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/Username/Project/blob/main/.github/CONTRIBUTING.md
-->
