### PR TITLE
Instructions on how to build documentation locally

### DIFF
--- a/Documentation/serve-website.png
+++ b/Documentation/serve-website.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5f8732be99a79ab82edfe925cf7dc7e9a84a959229246cce503bfed8d53223b
+size 104718

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,4 @@
 # Contributing
-If you'd like to contribute view the contribution docs [here](./contribution.md)
-
 You can pull or fork this project. It runs on dotnet core, so you should be able to run `dotnet test`
 You cannot commit to `main` - but feel free to make a Pull Request.
 Remember to add tests for your changes.
@@ -15,6 +13,22 @@ dotnet cake --target=Test
 ```
 
 The project is built with `dotnet-boxed`, so if you have any questions to the structure, check out [this article](https://rehansaeed.com/the-fastest-nuget-package-ever-published-probably/)
+
+# Building the documentation locally
+To build the documentation locally to test out things you will need to install doxygen.
+Installation instructions can be found [here](https://www.doxygen.nl/download.html) (scroll down to "Sources and Binaries")
+
+After having installed doxygen you can generate the documentation by running:
+```shell
+doxygen doxygen-config.toml
+```
+
+The documentation will be put into a gitignored `docs` folder
+You can go into `docs/html/index.html` and serve this page to see the documentation built locally.
+
+If you run Rider, you can serve the website right from your editor by opening the file and clicking the browser icons on the top right
+
+![./serve-website.png]()
 
 
 ### Before submitting a PR

--- a/contributing.md
+++ b/contributing.md
@@ -28,7 +28,7 @@ You can go into `docs/html/index.html` and serve this page to see the documentat
 
 If you run Rider, you can serve the website right from your editor by opening the file and clicking the browser icons on the top right
 
-![./serve-website.png]()
+![Serving websites in Rider](./serve-website.png)
 
 
 ### Before submitting a PR

--- a/contributing.md
+++ b/contributing.md
@@ -28,7 +28,7 @@ You can go into `docs/html/index.html` and serve this page to see the documentat
 
 If you run Rider, you can serve the website right from your editor by opening the file and clicking the browser icons on the top right
 
-![Serving websites in Rider](./serve-website.png)
+![Serving websites in Rider](Documentation/serve-website.png)
 
 
 ### Before submitting a PR


### PR DESCRIPTION
Add the instructions on how to build and serve the doxygen documentation locally.