### PR TITLE
PostAsJson should respect HttpClient BaseUrl

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -454,6 +454,7 @@ dotnet_diagnostic.SA1009.severity = none
 dotnet_diagnostic.SA1505.severity = none
 dotnet_diagnostic.SA1508.severity = none
 dotnet_diagnostic.SA1516.severity = none
+dotnet_diagnostic.SA1000.severity = none
 
 # Using directives
 dotnet_diagnostic.SA1012.severity = none

--- a/Source/SCM.SwissArmyKnife/Extensions/HttpClientExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/HttpClientExtensions.cs
@@ -76,11 +76,13 @@ namespace SCM.SwissArmyKnife.Extensions
 
 
         /// <summary>
-        /// POSTS to the <paramref name="url"/>, with a potentially provided <paramref name="jsonBody"/>.
+        /// POSTS to the <paramref name="uri"/>, with a potentially provided <paramref name="jsonBody"/>.
         /// The response is expected to be a JSON body and is serialized to <typeparamref name="TResponse"/>.
         /// </summary>
         /// <param name="httpClient">The HttpClient to use for the operation.</param>
-        /// <param name="url">The URL to POST to.</param>
+        /// <param name="uri">The URI to POST to. Note that this needs to be a fully qualified URI starting with http(s):
+        /// Any BaseAddress from the HttpClient is not respected.
+        /// </param>
         /// <param name="jsonBody">The object to be serialized to JSON and included in the body. If not specified or null, no body will be sent.</param>
         /// <param name="maxCharactersToPrint">
         /// If an error happen, how many characters of the HTTP response to include in the exception message.
@@ -91,9 +93,9 @@ namespace SCM.SwissArmyKnife.Extensions
         /// <typeparam name="TResponse">The response type to parse the returned JSON to.</typeparam>
         /// <returns>The response type serialized into <typeparamref name="TResponse"/>.</returns>
         ///
-        public static Task<TResponse> PostAsJsonAsync<TResponse>(this HttpClient httpClient, string url, object? jsonBody = null, int? maxCharactersToPrint = null)
+        public static Task<TResponse> PostAsJsonAsync<TResponse>(this HttpClient httpClient, Uri uri, object? jsonBody = null, int? maxCharactersToPrint = null)
         {
-            return PostAsJsonAsync<TResponse>(httpClient, new Uri(url), jsonBody, maxCharactersToPrint);
+            return PostAsJsonAsync<TResponse>(httpClient, uri.ToString(), jsonBody, maxCharactersToPrint);
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace SCM.SwissArmyKnife.Extensions
         /// The JSON response is serialized into an T.
         /// Throws an error on non-2xx status messages.
         /// </summary>
-        public static async Task<T> PostAsJsonAsync<T>(this HttpClient httpClient, Uri url, object? jsonBody = null, int? maxCharactersToPrint = null)
+        public static async Task<T> PostAsJsonAsync<T>(this HttpClient httpClient, string url, object? jsonBody = null, int? maxCharactersToPrint = null)
         {
             string? body = null;
 
@@ -118,6 +120,7 @@ namespace SCM.SwissArmyKnife.Extensions
                     content = new StringContent(string.Empty);
                 }
 
+                Console.WriteLine($"URL {url}");
                 var response = await httpClient.PostAsync(url, content).ConfigureAwait(false);
                 body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 response.EnsureSuccessStatusCode();

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SCM.SwissArmyKnife.Extensions;
 using Xunit;
 
@@ -103,6 +104,44 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             // Assert
             // Error body only contains 12345 and then a quote '
             await action.Should().ThrowAsync<HttpRequestException>().WithMessage($"*12345...*");
+        }
+
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task PostAsJson_ShouldRespectBasePath_WhenCalledWithStringAsUrl()
+        {
+            // Arrange
+            var client = new HttpClient()
+            {
+                BaseAddress = new Uri("https://postman-echo.com/")
+            };
+
+            // Act & Assert
+            // This should work without any issues, as the relative url provided is a string
+            var response = await client.PostAsJsonAsync<Dictionary<string, object>>("post?foo1=bar1");
+
+            response.Should().ContainKey("args").WhichValue.Should().BeEquivalentTo(new Dictionary<string, JValue>
+            {
+                {"foo1", new JValue("bar1")}
+            });
+        }
+
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task PostAsJson_ShouldThrowError_WhenCalledWithRelativeUri()
+        {
+            // Arrange
+            var client = new HttpClient()
+            {
+                BaseAddress = new Uri("https://postman-echo.com/")
+            };
+
+            // Act & Assert
+            // This should throw an error because a relative Uri is specified, which is not allowed.
+            Func<Task> actionThatThrows = async () => await client.PostAsJsonAsync<Dictionary<string, object>>(new Uri("/post?foo1=bar1&foo2=bar2"));
+
+            await actionThatThrows.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("*Only 'http' and 'https' schemes are allowed*");
         }
 
 

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
@@ -138,11 +138,12 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             // Act & Assert
             // This should throw an error because a relative Uri is specified, which is not allowed.
+            // It's technically throwing in the "new Uri" part, so it's not the best test.
             Func<Task> actionThatThrows = async () => await client.PostAsJsonAsync<Dictionary<string, object>>(new Uri("/post?foo1=bar1&foo2=bar2"));
 
             // Throws either ArgumentException or UriFormatException depending on platform
             await actionThatThrows.Should().ThrowAsync<SystemException>()
-                .WithMessage("*Only 'http' and 'https' schemes are allowed*");
+                .WithMessage("*scheme*"); // error message varies across platform
         }
 
         // This test relies on internet connection which isn't optimal

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
@@ -140,7 +140,8 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             // This should throw an error because a relative Uri is specified, which is not allowed.
             Func<Task> actionThatThrows = async () => await client.PostAsJsonAsync<Dictionary<string, object>>(new Uri("/post?foo1=bar1&foo2=bar2"));
 
-            await actionThatThrows.Should().ThrowAsync<ArgumentException>()
+            // Throws either ArgumentException or UriFormatException depending on platform
+            await actionThatThrows.Should().ThrowAsync<SystemException>()
                 .WithMessage("*Only 'http' and 'https' schemes are allowed*");
         }
 

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
@@ -142,8 +142,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
             Func<Task> actionThatThrows = async () => await client.PostAsJsonAsync<Dictionary<string, object>>(new Uri("/post?foo1=bar1&foo2=bar2"));
 
             // Throws either ArgumentException or UriFormatException depending on platform
-            await actionThatThrows.Should().ThrowAsync<SystemException>()
-                .WithMessage("*scheme*"); // error message varies across platform
+            await actionThatThrows.Should().ThrowAsync<SystemException>();
         }
 
         // This test relies on internet connection which isn't optimal

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
@@ -144,6 +144,45 @@ namespace SCM.SwissArmyKnife.Test.Extensions
                 .WithMessage("*Only 'http' and 'https' schemes are allowed*");
         }
 
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task PostAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUriInsteadOfString()
+        {
+            // Arrange
+            var client = new HttpClient()
+            {
+                BaseAddress = new Uri("https://some-not-real-address.com/")
+            };
+
+            // Act & Assert
+            // This should work as the Uri provided is fully qualified
+            var response = await client.PostAsJsonAsync<Dictionary<string, object>>(new Uri("https://postman-echo.com/post?foo1=bar1"));
+
+            response.Should().ContainKey("args").WhichValue.Should().BeEquivalentTo(new Dictionary<string, JValue>
+            {
+                {"foo1", new JValue("bar1")}
+            });
+        }
+
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task PostAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrl()
+        {
+            // Arrange
+            var client = new HttpClient()
+            {
+                BaseAddress = new Uri("https://some-not-real-address.com/")
+            };
+
+            // Act & Assert
+            // This should work as the Uri provided is fully qualified
+            var response = await client.PostAsJsonAsync<Dictionary<string, object>>("https://postman-echo.com/post?foo1=bar1");
+
+            response.Should().ContainKey("args").WhichValue.Should().BeEquivalentTo(new Dictionary<string, JValue>
+            {
+                {"foo1", new JValue("bar1")}
+            });
+        }
 
         // from https://gingter.org/2018/07/26/how-to-mock-httpclient-in-your-net-c-unit-tests/
         private static Mock<HttpMessageHandler> HttpMessageHandlerMock(HttpResponseMessage response)

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/RandomExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/RandomExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 {
     public class RandomExtensionsTests
     {
-        private readonly Random random = new();
+        private readonly Random random = new ();
 
         [Fact]
         public void NextDouble_ReturnsADouble_WithinSpecifiedRange()

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/RandomExtensionsTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/RandomExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 {
     public class RandomExtensionsTests
     {
-        private readonly Random random = new ();
+        private readonly Random random = new();
 
         [Fact]
         public void NextDouble_ReturnsADouble_WithinSpecifiedRange()


### PR DESCRIPTION
Fixes #26 

Turns out HttpClient actually treat URL's and URI's differently - so converting one blindly to the other doesn't work, as strings are considered relative paths, and URI's are considered fully qualified.

This means that trying to convert a string with a relative path (e.g. when having a BasePath specified) to a URI as we did previously doesn't actually work. I normally don't use BasePath so I hadn't spotted this issue, as if the string is a fully qualified URL, strings and URI's behave the same.

This should get around this issue by treating the "string" issue as the normal one, and the URI as the "special" case that maps to string, rather than the other way around.

Also added some tests to test this behaviour in non-mocked circumstances using the postman echo service. Unfortunately those tests can't run without internet, but that's life for now.