### PR TITLE
Make GetAsJson respect HttpClient basepath

### DIFF
--- a/Source/SCM.SwissArmyKnife/Extensions/HttpClientExtensions.cs
+++ b/Source/SCM.SwissArmyKnife/Extensions/HttpClientExtensions.cs
@@ -18,31 +18,34 @@ namespace SCM.SwissArmyKnife.Extensions
         /// Throws an error on non-2xx status messages.
         /// </summary>
         /// <param name="httpClient">HttpClient to use.</param>
-        /// <param name="url">Url to retrieve.</param>
+        /// <param name="uri">The URI to GET. Note that this needs to be a fully qualified URI starting with http(s):
+        /// Any BaseAddress from the HttpClient is not respected.
+        /// </param>
         /// <param name="maxCharactersToPrint">
         /// If any errors occurs, how many characters of the response body should be included in the response body?
         /// If set to null, records the entire response.
         /// </param>
         /// <typeparam name="TResponse">The type to attempt to serialize the JSON response to.</typeparam>
         /// <returns>The response from the server as <typeparamref name="TResponse"/>.</returns>
-        public static Task<TResponse> GetAsJsonAsync<TResponse>(this HttpClient httpClient, string url, int? maxCharactersToPrint = null)
+        public static Task<TResponse> GetAsJsonAsync<TResponse>(this HttpClient httpClient, Uri uri, int? maxCharactersToPrint = null)
         {
-            return GetAsJsonAsync<TResponse>(httpClient, new Uri(url), maxCharactersToPrint);
+            return GetAsJsonAsync<TResponse>(httpClient, uri.ToString(), maxCharactersToPrint);
         }
 
         /// <summary>
         /// GETs the given address, and serializes the resulting JSON object into an object of type T.
         /// Throws an error on non-2xx status messages.
+        /// The response is expected to be a JSON body and is serialized to <typeparamref name="TResponse"/>.
         /// </summary>
         /// <param name="httpClient">HttpClient to use.</param>
-        /// <param name="url">Url to retrieve.</param>
+        /// <param name="url">The URL to GET. This url has the same semantics as when using the regular "GetAsync" in regards to respecting BaseAddress.</param>
         /// <param name="maxCharactersToPrint">
         /// If any errors occurs, how many characters of the response body should be included in the response body?
         /// If set to null, records the entire response.
         /// </param>
         /// <typeparam name="TResponse">The type to attempt to serialize the JSON response to.</typeparam>
         /// <returns>The response from the server as <typeparamref name="TResponse"/>.</returns>
-        public static async Task<TResponse> GetAsJsonAsync<TResponse>(this HttpClient httpClient, Uri url, int? maxCharactersToPrint = null)
+        public static async Task<TResponse> GetAsJsonAsync<TResponse>(this HttpClient httpClient, string url, int? maxCharactersToPrint = null)
         {
             string? body = null;
             try

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsGetAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsGetAsJsonTests.cs
@@ -157,7 +157,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
         // This test relies on internet connection which isn't optimal
         [Fact]
-        public async Task GetAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrl()
+        public async Task GetAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrlAsString()
         {
             // Arrange
             var client = new HttpClient() { BaseAddress = new Uri("https://some-not-real-address.com/") };

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsGetAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsGetAsJsonTests.cs
@@ -20,12 +20,13 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         public async Task GetAsJson_ShouldReturnAsJson()
         {
             // Arrange
-            var originalDictionary = new Dictionary<string, string> {{"foo", "bar"}};
+            var originalDictionary = new Dictionary<string, string> { { "foo", "bar" } };
             var json = JsonConvert.SerializeObject(originalDictionary);
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK, Content = new StringContent(json)
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json)
             });
 
             var client = new HttpClient(handlerMock.Object);
@@ -46,7 +47,8 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.NotFound, Content = new StringContent(errorResponse)
+                StatusCode = HttpStatusCode.NotFound,
+                Content = new StringContent(errorResponse)
             });
 
             var client = new HttpClient(handlerMock.Object);
@@ -67,7 +69,8 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK, Content = new StringContent(serverResponse)
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(serverResponse)
             });
 
             var client = new HttpClient(handlerMock.Object);
@@ -88,7 +91,8 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.NotFound, Content = new StringContent(errorResponse)
+                StatusCode = HttpStatusCode.NotFound,
+                Content = new StringContent(errorResponse)
             });
 
             var client = new HttpClient(handlerMock.Object);
@@ -107,14 +111,14 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         public async Task GetAsJson_ShouldRespectBasePath_WhenCalledWithStringAsUrl()
         {
             // Arrange
-            var client = new HttpClient() {BaseAddress = new Uri("https://postman-echo.com/")};
+            var client = new HttpClient() { BaseAddress = new Uri("https://postman-echo.com/") };
 
             // Act & Assert
             // This should work without any issues, as the relative url provided is a string
             var response = await client.GetAsJsonAsync<Dictionary<string, object>>("get?foo1=bar1");
 
             response.Should().ContainKey("args").WhichValue.Should()
-                .BeEquivalentTo(new Dictionary<string, JValue> {{"foo1", new JValue("bar1")}});
+                .BeEquivalentTo(new Dictionary<string, JValue> { { "foo1", new JValue("bar1") } });
         }
 
         // This test relies on internet connection which isn't optimal
@@ -122,7 +126,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         public async Task GetAsJson_ShouldThrowError_WhenCalledWithRelativeUri()
         {
             // Arrange
-            var client = new HttpClient() {BaseAddress = new Uri("https://postman-echo.com/")};
+            var client = new HttpClient() { BaseAddress = new Uri("https://postman-echo.com/") };
 
             // Act & Assert
             // This should throw an error because a relative Uri is specified, which is not allowed.
@@ -139,7 +143,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         public async Task GetAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUriInsteadOfString()
         {
             // Arrange
-            var client = new HttpClient() {BaseAddress = new Uri("https://some-not-real-address.com/")};
+            var client = new HttpClient() { BaseAddress = new Uri("https://some-not-real-address.com/") };
 
             // Act & Assert
             // This should work as the Uri provided is fully qualified
@@ -148,7 +152,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
                     new Uri("https://postman-echo.com/get?foo1=bar1"));
 
             response.Should().ContainKey("args").WhichValue.Should()
-                .BeEquivalentTo(new Dictionary<string, JValue> {{"foo1", new JValue("bar1")}});
+                .BeEquivalentTo(new Dictionary<string, JValue> { { "foo1", new JValue("bar1") } });
         }
 
         // This test relies on internet connection which isn't optimal
@@ -156,7 +160,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
         public async Task GetAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrl()
         {
             // Arrange
-            var client = new HttpClient() {BaseAddress = new Uri("https://some-not-real-address.com/")};
+            var client = new HttpClient() { BaseAddress = new Uri("https://some-not-real-address.com/") };
 
             // Act & Assert
             // This should work as the Uri provided is fully qualified
@@ -164,7 +168,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
                 await client.GetAsJsonAsync<Dictionary<string, object>>("https://postman-echo.com/get?foo1=bar1");
 
             response.Should().ContainKey("args").WhichValue.Should()
-                .BeEquivalentTo(new Dictionary<string, JValue> {{"foo1", new JValue("bar1")}});
+                .BeEquivalentTo(new Dictionary<string, JValue> { { "foo1", new JValue("bar1") } });
         }
 
 

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsGetAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsGetAsJsonTests.cs
@@ -8,34 +8,31 @@ using FluentAssertions;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SCM.SwissArmyKnife.Extensions;
 using Xunit;
 
 namespace SCM.SwissArmyKnife.Test.Extensions
 {
-
     public class HttpClientExtensionsGetAsJsonTests
     {
         [Fact]
         public async Task GetAsJson_ShouldReturnAsJson()
         {
             // Arrange
-            var originalDictionary = new Dictionary<string, string>
-            {
-                {"foo", "bar"}
-            };
+            var originalDictionary = new Dictionary<string, string> {{"foo", "bar"}};
             var json = JsonConvert.SerializeObject(originalDictionary);
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(json)
+                StatusCode = HttpStatusCode.OK, Content = new StringContent(json)
             });
 
             var client = new HttpClient(handlerMock.Object);
 
             // Act
-            var dictionaryFromClient = await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com");
+            var dictionaryFromClient =
+                await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com");
 
             // Assert
             dictionaryFromClient.Should().BeEquivalentTo(originalDictionary);
@@ -49,14 +46,14 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.NotFound,
-                Content = new StringContent(errorResponse)
+                StatusCode = HttpStatusCode.NotFound, Content = new StringContent(errorResponse)
             });
 
             var client = new HttpClient(handlerMock.Object);
 
             // Act
-            Func<Task> action = async () => await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com");
+            Func<Task> action = async () =>
+                await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com");
 
             // Assert
             await action.Should().ThrowAsync<HttpRequestException>().WithMessage($"*{errorResponse}*");
@@ -70,14 +67,14 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(serverResponse)
+                StatusCode = HttpStatusCode.OK, Content = new StringContent(serverResponse)
             });
 
             var client = new HttpClient(handlerMock.Object);
 
             // Act
-            Func<Task> action = async () => await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com");
+            Func<Task> action = async () =>
+                await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com");
 
             // Assert
             await action.Should().ThrowAsync<JsonException>().WithMessage($"*{serverResponse}*");
@@ -91,20 +88,84 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
             var handlerMock = HttpMessageHandlerMock(new HttpResponseMessage
             {
-                StatusCode = HttpStatusCode.NotFound,
-                Content = new StringContent(errorResponse)
+                StatusCode = HttpStatusCode.NotFound, Content = new StringContent(errorResponse)
             });
 
             var client = new HttpClient(handlerMock.Object);
 
             // Act
-            Func<Task> action = async () => await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com", 5);
+            Func<Task> action = async () =>
+                await client.GetAsJsonAsync<Dictionary<string, string>>("http://doesntmatter.com", 5);
 
             // Assert
             // Error body only contains 12345 and then a quote '
             await action.Should().ThrowAsync<HttpRequestException>().WithMessage($"*12345...*");
         }
 
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task GetAsJson_ShouldRespectBasePath_WhenCalledWithStringAsUrl()
+        {
+            // Arrange
+            var client = new HttpClient() {BaseAddress = new Uri("https://postman-echo.com/")};
+
+            // Act & Assert
+            // This should work without any issues, as the relative url provided is a string
+            var response = await client.GetAsJsonAsync<Dictionary<string, object>>("get?foo1=bar1");
+
+            response.Should().ContainKey("args").WhichValue.Should()
+                .BeEquivalentTo(new Dictionary<string, JValue> {{"foo1", new JValue("bar1")}});
+        }
+
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task GetAsJson_ShouldThrowError_WhenCalledWithRelativeUri()
+        {
+            // Arrange
+            var client = new HttpClient() {BaseAddress = new Uri("https://postman-echo.com/")};
+
+            // Act & Assert
+            // This should throw an error because a relative Uri is specified, which is not allowed.
+            // It's technically throwing in the "new Uri" part, so it's not the best test.
+            Func<Task> actionThatThrows = async () =>
+                await client.GetAsJsonAsync<Dictionary<string, object>>(new Uri("/get?foo1=bar1&foo2=bar2"));
+
+            // Throws either ArgumentException or UriFormatException depending on platform
+            await actionThatThrows.Should().ThrowAsync<SystemException>();
+        }
+
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task GetAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUriInsteadOfString()
+        {
+            // Arrange
+            var client = new HttpClient() {BaseAddress = new Uri("https://some-not-real-address.com/")};
+
+            // Act & Assert
+            // This should work as the Uri provided is fully qualified
+            var response =
+                await client.GetAsJsonAsync<Dictionary<string, object>>(
+                    new Uri("https://postman-echo.com/get?foo1=bar1"));
+
+            response.Should().ContainKey("args").WhichValue.Should()
+                .BeEquivalentTo(new Dictionary<string, JValue> {{"foo1", new JValue("bar1")}});
+        }
+
+        // This test relies on internet connection which isn't optimal
+        [Fact]
+        public async Task GetAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrl()
+        {
+            // Arrange
+            var client = new HttpClient() {BaseAddress = new Uri("https://some-not-real-address.com/")};
+
+            // Act & Assert
+            // This should work as the Uri provided is fully qualified
+            var response =
+                await client.GetAsJsonAsync<Dictionary<string, object>>("https://postman-echo.com/get?foo1=bar1");
+
+            response.Should().ContainKey("args").WhichValue.Should()
+                .BeEquivalentTo(new Dictionary<string, JValue> {{"foo1", new JValue("bar1")}});
+        }
 
 
         // from https://gingter.org/2018/07/26/how-to-mock-httpclient-in-your-net-c-unit-tests/

--- a/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
+++ b/Tests/SCM.SwissArmyKnife.Test/Extensions/HttpClientExtensionsPostAsJsonTests.cs
@@ -167,7 +167,7 @@ namespace SCM.SwissArmyKnife.Test.Extensions
 
         // This test relies on internet connection which isn't optimal
         [Fact]
-        public async Task PostAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrl()
+        public async Task PostAsJson_ShouldIgnoreBasePath_WhenCalledWithFullyQualifiedUrlAsString()
         {
             // Arrange
             var client = new HttpClient()


### PR DESCRIPTION
Same fix as in #27, but just for `GetAsJson` as well.

<!--
Thank you good citizen for your hard work!

Please read the contributing guide before raising a pull request.
https://github.com/Username/Project/blob/main/.github/CONTRIBUTING.md
-->
